### PR TITLE
[#25] 게시글 조회 기능 구현

### DIFF
--- a/src/main/java/com/been/foodieserver/controller/PostController.java
+++ b/src/main/java/com/been/foodieserver/controller/PostController.java
@@ -5,6 +5,7 @@ import com.been.foodieserver.dto.response.ApiResponse;
 import com.been.foodieserver.dto.response.PostResponse;
 import com.been.foodieserver.service.PostService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,7 +17,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("${api.endpoint.base-url}/posts")
@@ -24,6 +28,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+
+    /**
+     * @param pageNum  페이지 번호 (1 시작)
+     * @param pageSize 페이지 당 게시글 수
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getPostList(@RequestParam(value = "pageNum", defaultValue = "1") @Min(1) int pageNum,
+                                                                       @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+        return ResponseEntity.ok(ApiResponse.success(postService.getPostList(pageNum, pageSize)));
+    }
 
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable("postId") Long postId) {

--- a/src/main/java/com/been/foodieserver/dto/response/ApiResponse.java
+++ b/src/main/java/com/been/foodieserver/dto/response/ApiResponse.java
@@ -1,11 +1,15 @@
 package com.been.foodieserver.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -15,23 +19,35 @@ public class ApiResponse<T> {
     private String status;
     private String message;
     private T data;
+    private Pagination pagination;
 
     public static final String STATUS_SUCCESS = "success";
     public static final String STATUS_FAIL = "fail";
     public static final String STATUS_ERROR = "error";
 
-    public ApiResponse(String status, String message, T data) {
+    private ApiResponse(String status, String message, T data) {
         this.status = status;
         this.message = message;
         this.data = data;
     }
 
+    private ApiResponse(String status, String message, T data, Pagination pagination) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+        this.pagination = pagination;
+    }
+
     public static <T> ApiResponse<T> success() {
-        return success(null);
+        return new ApiResponse<>(STATUS_SUCCESS, null, null);
     }
 
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(STATUS_SUCCESS, null, data);
+    }
+
+    public static <T> ApiResponse<List<T>> success(Page<T> page) {
+        return new ApiResponse<>(STATUS_SUCCESS, null, page.getContent(), Pagination.of(page));
     }
 
     public static <T> ApiResponse<T> fail(String message) {
@@ -61,5 +77,21 @@ public class ApiResponse<T> {
         bindingResult.getFieldErrors()
                 .forEach(b -> errorMap.put(b.getField(), b.getDefaultMessage()));
         return new ApiResponse<>(STATUS_FAIL, "field errors", errorMap);
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Pagination {
+
+        private int currentPage; //현재 페이지
+        private int totalPages; //전체 페이지 수
+        private long totalElements; //전체 데이터 수
+        private int pageSize; //한 페이지 당 데이터 개수
+        private Boolean hasPrevious;
+        private Boolean hasNext;
+
+        public static Pagination of(Page<?> page) {
+            return new Pagination(page.getNumber() + 1, page.getTotalPages(), page.getTotalElements(), page.getSize(), page.hasPrevious(), page.hasNext());
+        }
     }
 }

--- a/src/main/java/com/been/foodieserver/repository/PostRepository.java
+++ b/src/main/java/com/been/foodieserver/repository/PostRepository.java
@@ -1,12 +1,17 @@
 package com.been.foodieserver.repository;
 
 import com.been.foodieserver.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @EntityGraph(attributePaths = {"user", "category"})
+    Page<Post> findAll(Pageable pageable);
 
     Optional<Post> findByIdAndUser_LoginId(Long postId, String userLoginId);
 

--- a/src/main/java/com/been/foodieserver/service/PostService.java
+++ b/src/main/java/com/been/foodieserver/service/PostService.java
@@ -11,6 +11,10 @@ import com.been.foodieserver.repository.CategoryRepository;
 import com.been.foodieserver.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +27,11 @@ public class PostService {
     private final UserService userService;
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
+
+    public Page<PostResponse> getPostList(int pageNum, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNum - 1, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        return postRepository.findAll(pageable).map(PostResponse::of);
+    }
 
     public PostResponse getPost(Long postId) {
         Post post = postRepository.findWithFetchJoinById(postId)

--- a/src/test/java/com/been/foodieserver/service/PostServiceTest.java
+++ b/src/test/java/com/been/foodieserver/service/PostServiceTest.java
@@ -17,8 +17,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,6 +63,36 @@ class PostServiceTest {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();
+    }
+
+    @DisplayName("게시글 목록 요청이 유효하면 게시글 목록 조회 성공")
+    @Test
+    void getPostList_IfRequestIsValid() {
+        //Given
+        Post post1 = PostFixture.get("title1", "user", "자유 게시판");
+        Post post2 = PostFixture.get("title2", "user", "자유 게시판");
+
+        List<Post> content = List.of(post2, post1);
+        Page<Post> postPage = new PageImpl<>(content);
+
+        int pageNum = 1;
+        int pageSize = content.size();
+
+        given(postRepository.findAll(any(Pageable.class))).willReturn(postPage);
+
+        //When
+        Page<PostResponse> result = postService.getPostList(pageNum, pageSize);
+
+        //Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(content.size());
+        assertThat(result.getNumber() + 1).isEqualTo(pageNum);
+        assertThat(result.getSize()).isEqualTo(pageSize);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo(post2.getTitle());
+
+        then(postRepository).should().findAll(any(Pageable.class));
+        then(userService).shouldHaveNoInteractions();
+        then(categoryRepository).shouldHaveNoInteractions();
     }
 
     @DisplayName("게시글 요청이 유효하면 게시글 조회 성공")


### PR DESCRIPTION
- 게시글 상세 조회 기능 구현
- 게시글 목록 조회(페이징) 기능 구현
  - 파라미터: 페이지 번호(1 시작), 페이지 당 게시글 수
  - ID 내림차순 정렬
- `ApiResponse`: 페이지 정보 반환 구현
- 테스트