### PR TITLE
[#23] 유저 수정/삭제 기능에서 응답에 수정/삭제 날짜가 제대로 반영되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/been/foodieserver/service/UserService.java
+++ b/src/main/java/com/been/foodieserver/service/UserService.java
@@ -72,6 +72,8 @@ public class UserService {
         User user = getUserOrException(loginId);
         user.modifyInfo(userDto.getNickname());
 
+        userRepository.flush();
+
         return UserInfoResponse.my(user);
     }
 
@@ -92,6 +94,9 @@ public class UserService {
     public UserInfoResponse deleteUser(String loginId) {
         User user = getUserOrException(loginId);
         user.withdraw();
+
+        userRepository.flush();
+
         return UserInfoResponse.my(user);
     }
 

--- a/src/test/java/com/been/foodieserver/service/UserServiceTest.java
+++ b/src/test/java/com/been/foodieserver/service/UserServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -273,6 +274,7 @@ class UserServiceTest {
 
         given(userRepository.existsByNicknameAndLoginIdIsNot(userDto.getNickname(), loginId)).willReturn(false);
         given(userRepository.findByLoginId(loginId)).willReturn(Optional.of(user));
+        willDoNothing().given(userRepository).flush();
 
         //When
         UserInfoResponse result = userService.modifyMyInfo(loginId, userDto);
@@ -283,6 +285,7 @@ class UserServiceTest {
 
         then(userRepository).should().existsByNicknameAndLoginIdIsNot(userDto.getNickname(), loginId);
         then(userRepository).should().findByLoginId(loginId);
+        then(userRepository).should().flush();
     }
 
     @DisplayName("닉네임 수정 시 다른 유저의 닉네임과 중복되면 예외 발생")
@@ -374,6 +377,7 @@ class UserServiceTest {
     void setDeletionDate_WhenDeletingUser() {
         //Given
         when(userRepository.findByLoginId(user.getLoginId())).thenReturn(Optional.of(user));
+        willDoNothing().given(userRepository).flush();
 
         //When
         userService.deleteUser(user.getLoginId());
@@ -382,5 +386,6 @@ class UserServiceTest {
         assertThat(user).hasFieldOrProperty("deletedAt");
 
         then(userRepository).should().findByLoginId(user.getLoginId());
+        then(userRepository).should().flush();
     }
 }


### PR DESCRIPTION
- `User`를 `UserInfoResponse`로 변환하기 전 flush 해서 `User`에 변경된 날짜 값이 업데이트 되게 함
- 테스트 수정