### PR TITLE
[#71] 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     //querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     //slack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9093
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
+      - JWT_SECRET=${JWT_SECRET}
     ports:
       - "80:8080"
     networks:

--- a/src/main/java/com/been/foodieserver/config/SecurityConfig.java
+++ b/src/main/java/com/been/foodieserver/config/SecurityConfig.java
@@ -29,6 +29,10 @@ public class SecurityConfig {
             "/api/*/users/sign-up", "/api/*/users/login", "/api/*/users/id/exists", "/api/*/users/nickname/exists", "/manage/**"
     };
 
+    private static final String[] CHAT_WHITE_LIST = {
+            "/chat", "/pub/chat/message", "/sub/chat-rooms/**", "/api/*/chat-rooms/**"
+    };
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
@@ -44,6 +48,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers(WHITE_LIST).permitAll()
+                        .requestMatchers(CHAT_WHITE_LIST).permitAll()
                         .requestMatchers("/refresh/**").hasRole(Role.ADMIN.getRoleName())
                         .anyRequest().authenticated())
                 .exceptionHandling(config -> config

--- a/src/main/java/com/been/foodieserver/config/WebSocketConfig.java
+++ b/src/main/java/com/been/foodieserver/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.been.foodieserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@EnableWebSocketMessageBroker
+@Configuration
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/sub");
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat")
+                .setAllowedOriginPatterns("*");
+    }
+}

--- a/src/main/java/com/been/foodieserver/controller/ChatRoomController.java
+++ b/src/main/java/com/been/foodieserver/controller/ChatRoomController.java
@@ -1,0 +1,38 @@
+package com.been.foodieserver.controller;
+
+import com.been.foodieserver.dto.ChatRoomDto;
+import com.been.foodieserver.dto.response.ApiResponse;
+import com.been.foodieserver.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("${api.endpoint.base-url}/chat-rooms")
+@RestController
+public class ChatRoomController {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ChatRoomDto>>> getRoomList() {
+        return ResponseEntity.ok(ApiResponse.success(chatRoomRepository.findAll()));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChatRoomDto>> createRoom(@RequestParam("name") String name) {
+        return ResponseEntity.ok(ApiResponse.success(chatRoomRepository.create(name)));
+    }
+
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse<ChatRoomDto>> getRoom(@PathVariable("roomId") String roomId) {
+        return ResponseEntity.ok(ApiResponse.success(chatRoomRepository.findById(roomId)));
+    }
+}

--- a/src/main/java/com/been/foodieserver/controller/WebSocketController.java
+++ b/src/main/java/com/been/foodieserver/controller/WebSocketController.java
@@ -1,0 +1,22 @@
+package com.been.foodieserver.controller;
+
+import com.been.foodieserver.dto.ChatMessageDto;
+import com.been.foodieserver.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+
+@RequiredArgsConstructor
+@Controller
+public class WebSocketController {
+
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @MessageMapping("/chat/message")
+    public void message(ChatMessageDto message) {
+        messagingTemplate.convertAndSend("/sub/chat-rooms/" + message.getRoomId(), message);
+        chatRoomRepository.increaseMessageCount(message.getRoomId());
+    }
+}

--- a/src/main/java/com/been/foodieserver/dto/ChatMessageDto.java
+++ b/src/main/java/com/been/foodieserver/dto/ChatMessageDto.java
@@ -1,0 +1,20 @@
+package com.been.foodieserver.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@NoArgsConstructor
+@Getter
+public class ChatMessageDto {
+
+    private MessageType type;
+    private String roomId;
+    private String sender;
+    private String message;
+
+    public enum MessageType {
+        ENTER, TALK, EXIT
+    }
+}

--- a/src/main/java/com/been/foodieserver/dto/ChatRoomDto.java
+++ b/src/main/java/com/been/foodieserver/dto/ChatRoomDto.java
@@ -1,0 +1,32 @@
+package com.been.foodieserver.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.UUID;
+
+@ToString
+@NoArgsConstructor
+@Getter
+public class ChatRoomDto {
+
+    private String roomId;
+    private String name;
+    private int messageCount;
+
+    @Builder
+    private ChatRoomDto(String name) {
+        this.roomId = UUID.randomUUID().toString();
+        this.name = name;
+    }
+
+    public static ChatRoomDto create(String name) {
+        return ChatRoomDto.builder().name(name).build();
+    }
+
+    public void increaseMessageCount() {
+        messageCount++;
+    }
+}

--- a/src/main/java/com/been/foodieserver/repository/ChatRoomRepository.java
+++ b/src/main/java/com/been/foodieserver/repository/ChatRoomRepository.java
@@ -1,0 +1,37 @@
+package com.been.foodieserver.repository;
+
+import com.been.foodieserver.dto.ChatRoomDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class ChatRoomRepository {
+
+    private Map<String, ChatRoomDto> chatRoomMap = new LinkedHashMap<>();
+
+    public List<ChatRoomDto> findAll() {
+        ArrayList<ChatRoomDto> chatRooms = new ArrayList<>(chatRoomMap.values());
+        Collections.reverse(chatRooms);
+        return chatRooms;
+    }
+
+    public ChatRoomDto findById(String id) {
+        return chatRoomMap.get(id);
+    }
+
+    public ChatRoomDto create(String name) {
+        ChatRoomDto chatRoom = ChatRoomDto.create(name);
+        chatRoomMap.put(chatRoom.getRoomId(), chatRoom);
+        return chatRoom;
+    }
+
+    public void increaseMessageCount(String id) {
+        ChatRoomDto chatRoom = findById(id);
+        chatRoom.increaseMessageCount();
+    }
+}


### PR DESCRIPTION
`WebSocket`을 사용하여 채팅 기능을 구현한다.

- `WebSocket` 디펜던시 추가
- `ws://{host}:{port}/chat`으로 WebSocket 연결 (stomp 통신)
- 연결 후 `/pub/chat/message`로 메세지를 보내면 해당 채팅방(`/sub/chat-rooms/{roomId}`)을 구독한 사용자에게 메세지가 전송됨
- 채팅방은 `Map`에 저장
- [apic](https://apic.app/online/#/tester)으로 테스트