### PR TITLE
[#73] 인기 검색어 기능 구현

### DIFF
--- a/src/main/java/com/been/foodieserver/controller/PostSearchController.java
+++ b/src/main/java/com/been/foodieserver/controller/PostSearchController.java
@@ -3,6 +3,7 @@ package com.been.foodieserver.controller;
 import com.been.foodieserver.dto.request.PostSearchRequest;
 import com.been.foodieserver.dto.response.ApiResponse;
 import com.been.foodieserver.dto.response.PostResponse;
+import com.been.foodieserver.dto.response.PostSearchRankResponse;
 import com.been.foodieserver.service.PostSearchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +16,22 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("${api.endpoint.base-url}/posts")
+@RequestMapping("${api.endpoint.base-url}/posts/search")
 @RestController
 public class PostSearchController {
 
     private final PostSearchService postSearchService;
 
-    @GetMapping("/search")
+    @GetMapping
     public ResponseEntity<ApiResponse<List<PostResponse>>> searchPost(@RequestBody @Valid PostSearchRequest request) {
         return ResponseEntity.ok(ApiResponse.success(postSearchService.search(request.toDto())));
+    }
+
+    /**
+     * 게시글 제목 기준 인기 검색어 10개를 반환합니다.
+     */
+    @GetMapping("/rank")
+    public ResponseEntity<ApiResponse<List<PostSearchRankResponse>>> searchPostRankList() {
+        return ResponseEntity.ok(ApiResponse.success(postSearchService.getTop10SearchKeywords()));
     }
 }

--- a/src/main/java/com/been/foodieserver/dto/response/PostSearchRankResponse.java
+++ b/src/main/java/com/been/foodieserver/dto/response/PostSearchRankResponse.java
@@ -1,0 +1,17 @@
+package com.been.foodieserver.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostSearchRankResponse {
+
+    private String keyword;
+    private Double score;
+
+    public static PostSearchRankResponse of(String keyword, Double score) {
+        return new PostSearchRankResponse(keyword, score);
+    }
+}

--- a/src/main/java/com/been/foodieserver/repository/PostQueryRepository.java
+++ b/src/main/java/com/been/foodieserver/repository/PostQueryRepository.java
@@ -61,10 +61,10 @@ public class PostQueryRepository {
     }
 
     private BooleanExpression writerLoginIdContainsIgnoreCase(String writerLoginId) {
-        return StringUtils.hasText(writerLoginId) ? user.loginId.containsIgnoreCase(writerLoginId) : null;
+        return StringUtils.hasText(writerLoginId) ? user.loginId.containsIgnoreCase(writerLoginId.trim()) : null;
     }
 
     private BooleanExpression postTitleContainsIgnoreCase(String title) {
-        return StringUtils.hasText(title) ? post.title.containsIgnoreCase(title) : null;
+        return StringUtils.hasText(title) ? post.title.containsIgnoreCase(title.trim()) : null;
     }
 }

--- a/src/main/java/com/been/foodieserver/repository/PostQueryRepository.java
+++ b/src/main/java/com/been/foodieserver/repository/PostQueryRepository.java
@@ -2,6 +2,7 @@ package com.been.foodieserver.repository;
 
 import com.been.foodieserver.domain.Post;
 import com.been.foodieserver.dto.PostSearchDto;
+import com.been.foodieserver.repository.cache.PostSearchCacheRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,8 +26,13 @@ import static com.been.foodieserver.domain.QUser.user;
 public class PostQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PostSearchCacheRepository postSearchCacheRepository;
 
     public Page<Post> findAllByUserLoginIdContainsIgnoreCaseAndTitleContainsIgnoreCase(PostSearchDto dto) {
+        if (dto.getTitle() != null) {
+            postSearchCacheRepository.incrementSearchKeywordCount(dto.getTitle());
+        }
+
         Pageable pageable = PageRequest.of(dto.getPageNum() - 1, dto.getPageSize(), Sort.by(Sort.Direction.DESC, "id"));
 
         List<Post> content = queryFactory
@@ -51,7 +57,6 @@ public class PostQueryRepository {
                         writerLoginIdContainsIgnoreCase(dto.getWriterLoginId()),
                         postTitleContainsIgnoreCase(dto.getTitle())
                 );
-
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 

--- a/src/main/java/com/been/foodieserver/repository/cache/PostSearchCacheRepository.java
+++ b/src/main/java/com/been/foodieserver/repository/cache/PostSearchCacheRepository.java
@@ -1,0 +1,35 @@
+package com.been.foodieserver.repository.cache;
+
+import com.been.foodieserver.dto.response.PostSearchRankResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class PostSearchCacheRepository {
+
+    private static final String POST_SEARCH_RANK_KEY = "post:search:rank";
+
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    public List<PostSearchRankResponse> getSearchKeywordsRank(int start, int end) {
+        Set<ZSetOperations.TypedTuple<String>> typedTuples = stringRedisTemplate.opsForZSet().reverseRangeWithScores(POST_SEARCH_RANK_KEY, start, end);
+        if (typedTuples == null || typedTuples.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return typedTuples.stream().map(tuple -> PostSearchRankResponse.of(tuple.getValue(), tuple.getScore())).toList();
+    }
+
+    public void incrementSearchKeywordCount(String keyword) {
+        keyword = keyword.trim();
+        stringRedisTemplate.opsForZSet().incrementScore(POST_SEARCH_RANK_KEY, keyword, 1.0);
+    }
+}

--- a/src/main/java/com/been/foodieserver/service/PostSearchService.java
+++ b/src/main/java/com/been/foodieserver/service/PostSearchService.java
@@ -2,20 +2,30 @@ package com.been.foodieserver.service;
 
 import com.been.foodieserver.dto.PostSearchDto;
 import com.been.foodieserver.dto.response.PostResponse;
+import com.been.foodieserver.dto.response.PostSearchRankResponse;
 import com.been.foodieserver.repository.PostQueryRepository;
+import com.been.foodieserver.repository.cache.PostSearchCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class PostSearchService {
 
     private final PostQueryRepository postQueryRepository;
+    private final PostSearchCacheRepository postSearchCacheRepository;
 
     @Transactional(readOnly = true)
     public Page<PostResponse> search(PostSearchDto dto) {
         return postQueryRepository.findAllByUserLoginIdContainsIgnoreCaseAndTitleContainsIgnoreCase(dto).map(PostResponse::of);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostSearchRankResponse> getTop10SearchKeywords() {
+        return postSearchCacheRepository.getSearchKeywordsRank(0, 9);
     }
 }


### PR DESCRIPTION
- 게시글 제목 기준으로 상위 검색어를 10개 반환한다.
- 검색어 순위는 Redis의 Sorted Set을 이용해 저장한다. key는 `post:search:rank`이다.
- 현재 Sorted Set의 score 기준은 해당 단어에 대한 검색 횟수이다. 향후 기준을 변경할 수 있다.