### PR TITLE
[#75] 게시글 검색: 작성자 닉네임으로 검색하게 수정 및 한 가지 조건으로만 검색하게 수정

### DIFF
--- a/src/main/java/com/been/foodieserver/dto/PostSearchDto.java
+++ b/src/main/java/com/been/foodieserver/dto/PostSearchDto.java
@@ -8,15 +8,15 @@ import lombok.ToString;
 @Getter
 public class PostSearchDto {
 
-    private final String writerLoginId;
-    private final String title;
+    private final PostSearchType searchType;
+    private final String keyword;
     private final Integer pageNum;
     private final Integer pageSize;
 
     @Builder
-    private PostSearchDto(String writerLoginId, String title, Integer pageNum, Integer pageSize) {
-        this.writerLoginId = writerLoginId;
-        this.title = title;
+    private PostSearchDto(PostSearchType searchType, String keyword, Integer pageNum, Integer pageSize) {
+        this.searchType = searchType;
+        this.keyword = keyword;
         this.pageNum = pageNum;
         this.pageSize = pageSize;
     }

--- a/src/main/java/com/been/foodieserver/dto/PostSearchType.java
+++ b/src/main/java/com/been/foodieserver/dto/PostSearchType.java
@@ -1,0 +1,5 @@
+package com.been.foodieserver.dto;
+
+public enum PostSearchType {
+    WRITER_NICKNAME, TITLE
+}

--- a/src/main/java/com/been/foodieserver/dto/request/PostSearchRequest.java
+++ b/src/main/java/com/been/foodieserver/dto/request/PostSearchRequest.java
@@ -1,6 +1,9 @@
 package com.been.foodieserver.dto.request;
 
 import com.been.foodieserver.dto.PostSearchDto;
+import com.been.foodieserver.dto.PostSearchType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,9 +14,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PostSearchRequest {
 
-    private String writerLoginId;
+    @NotNull
+    private PostSearchType searchType;
 
-    private String title;
+    @NotBlank
+    private String keyword;
 
     @Positive
     private Integer pageNum = 1;
@@ -23,8 +28,8 @@ public class PostSearchRequest {
 
     public PostSearchDto toDto() {
         return PostSearchDto.builder()
-                .writerLoginId(writerLoginId)
-                .title(title)
+                .searchType(searchType)
+                .keyword(keyword)
                 .pageNum(pageNum)
                 .pageSize(pageSize)
                 .build();

--- a/src/main/java/com/been/foodieserver/service/PostSearchService.java
+++ b/src/main/java/com/been/foodieserver/service/PostSearchService.java
@@ -21,7 +21,10 @@ public class PostSearchService {
 
     @Transactional(readOnly = true)
     public Page<PostResponse> search(PostSearchDto dto) {
-        return postQueryRepository.findAllByUserLoginIdContainsIgnoreCaseAndTitleContainsIgnoreCase(dto).map(PostResponse::of);
+        return switch (dto.getSearchType()) {
+            case WRITER_NICKNAME -> postQueryRepository.findAllByUserNicknameContainsIgnoreCase(dto).map(PostResponse::of);
+            case TITLE -> postQueryRepository.findAllByTitleContainsIgnoreCase(dto).map(PostResponse::of);
+        };
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/been/foodieserver/controller/PostSearchControllerTest.java
+++ b/src/test/java/com/been/foodieserver/controller/PostSearchControllerTest.java
@@ -2,6 +2,7 @@ package com.been.foodieserver.controller;
 
 import com.been.foodieserver.domain.Post;
 import com.been.foodieserver.dto.PostSearchDto;
+import com.been.foodieserver.dto.PostSearchType;
 import com.been.foodieserver.dto.request.PostSearchRequest;
 import com.been.foodieserver.dto.response.ApiResponse;
 import com.been.foodieserver.dto.response.PostResponse;
@@ -56,7 +57,7 @@ class PostSearchControllerTest {
         int pageNum = 1;
         int pageSize = 10;
 
-        PostSearchRequest request = new PostSearchRequest("writer", "title", pageNum, pageSize);
+        PostSearchRequest request = new PostSearchRequest(PostSearchType.TITLE, "title", pageNum, pageSize);
 
         Post post1 = PostFixture.get("title1", "writer", "자유 게시판");
         Post post2 = PostFixture.get("title2", "writer", "자유 게시판");

--- a/src/test/java/com/been/foodieserver/repository/PostQueryRepositoryTest.java
+++ b/src/test/java/com/been/foodieserver/repository/PostQueryRepositoryTest.java
@@ -6,9 +6,11 @@ import com.been.foodieserver.domain.Post;
 import com.been.foodieserver.domain.Role;
 import com.been.foodieserver.domain.User;
 import com.been.foodieserver.dto.PostSearchDto;
+import com.been.foodieserver.dto.PostSearchType;
 import com.been.foodieserver.repository.cache.PostSearchCacheRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -61,14 +63,12 @@ class PostQueryRepositoryTest {
     private static final String TITLE_9 = "hhhhh";
     private static final String TITLE_10 = "test";
 
-    @DisplayName("작성자 아이디가 포함되고 제목이 포함되는 게시글 검색")
-    @MethodSource
-    @ParameterizedTest
-    void findPostPageByWriterIdAndTitleContaining(String searchLoginId, String searchTitle, List<String> expected) {
-        //Given
+    @BeforeEach
+    void setUp() {
         User user1 = User.of("writer1", "pwd", "writer1", null, Role.USER);
         User user2 = User.of("writer2", "pwd", "writer2", null, Role.USER);
-        userRepository.saveAllAndFlush(List.of(user1, user2));
+        User user3 = User.of("user3", "pwd", "user3", null, Role.USER);
+        userRepository.saveAllAndFlush(List.of(user1, user2, user3));
 
         Category category = Category.of("category", null);
         categoryRepository.saveAndFlush(category);
@@ -76,67 +76,113 @@ class PostQueryRepositoryTest {
         Post post1 = Post.of(user1, category, TITLE_1, "content");
         Post post2 = Post.of(user1, category, TITLE_2, "content");
         Post post3 = Post.of(user1, category, TITLE_3, "content");
-        Post post4 = Post.of(user1, category, TITLE_4, "content");
-        Post post5 = Post.of(user1, category, TITLE_5, "content");
-        Post post6 = Post.of(user1, category, TITLE_6, "content");
+        Post post4 = Post.of(user2, category, TITLE_4, "content");
+        Post post5 = Post.of(user2, category, TITLE_5, "content");
+        Post post6 = Post.of(user2, category, TITLE_6, "content");
         Post post7 = Post.of(user2, category, TITLE_7, "content");
-        Post post8 = Post.of(user2, category, TITLE_8, "content");
-        Post post9 = Post.of(user2, category, TITLE_9, "content");
-        Post post10 = Post.of(user2, category, TITLE_10, "content");
+        Post post8 = Post.of(user3, category, TITLE_8, "content");
+        Post post9 = Post.of(user3, category, TITLE_9, "content");
+        Post post10 = Post.of(user3, category, TITLE_10, "content");
         postRepository.saveAllAndFlush(List.of(post1, post2, post3, post4, post5, post6, post7, post8, post9, post10));
+    }
 
+    @DisplayName("작성자 닉네임 기준 게시글 검색")
+    @MethodSource
+    @ParameterizedTest
+    void findPostPageByWriterNickname(String nickname, List<String> expected) {
+        //Given
         PostSearchDto dto = PostSearchDto.builder()
-                .writerLoginId(searchLoginId)
-                .title(searchTitle)
+                .searchType(PostSearchType.WRITER_NICKNAME)
+                .keyword(nickname)
                 .pageNum(1)
                 .pageSize(10)
                 .build();
 
         //When
-        Page<Post> result = postQueryRepository.findAllByUserLoginIdContainsIgnoreCaseAndTitleContainsIgnoreCase(dto);
+        Page<Post> result = postQueryRepository.findAllByUserNicknameContainsIgnoreCase(dto);
         List<String> actual = result.getContent().stream()
                 .map(Post::getTitle)
                 .toList();
 
         //Then
         assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
-        if (searchTitle == null) {
-            then(postSearchCacheRepository).shouldHaveNoInteractions();
-        } else {
-            then(postSearchCacheRepository).should().incrementSearchKeywordCount(searchTitle);
+        then(postSearchCacheRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("게시글 제목 기준 게시글 검색")
+    @MethodSource
+    @ParameterizedTest
+    void findPostPageByTitle(String title, List<String> expected) {
+        //Given
+        PostSearchDto dto = PostSearchDto.builder()
+                .searchType(PostSearchType.TITLE)
+                .keyword(title)
+                .pageNum(1)
+                .pageSize(10)
+                .build();
+
+        //When
+        Page<Post> result = postQueryRepository.findAllByTitleContainsIgnoreCase(dto);
+        List<String> actual = result.getContent().stream()
+                .map(Post::getTitle)
+                .toList();
+
+        //Then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        if (title != null && !title.isBlank()) {
+            then(postSearchCacheRepository).should().incrementSearchKeywordCount(title);
         }
     }
 
-    static Stream<Arguments> findPostPageByWriterIdAndTitleContaining() {
+    static Stream<Arguments> findPostPageByWriterNickname() {
         /*
         Post post1 = Post.of(user1, category, "Hello World", "content");
         Post post2 = Post.of(user1, category, "hello w", "content");
         Post post3 = Post.of(user1, category, "Hello world?", "content");
-        Post post4 = Post.of(user1, category, "hello wor", "content");
-        Post post5 = Post.of(user1, category, "Hello worl", "content");
-        Post post6 = Post.of(user1, category, "WORLD", "content");
+        Post post4 = Post.of(user2, category, "hello wor", "content");
+        Post post5 = Post.of(user2, category, "Hello worl", "content");
+        Post post6 = Post.of(user2, category, "WORLD", "content");
         Post post7 = Post.of(user2, category, "worl", "content");
-        Post post8 = Post.of(user2, category, "llo world hello", "content");
-        Post post9 = Post.of(user2, category, "hhhhh", "content");
-        Post post10 = Post.of(user2, category, "test", "content");
+        Post post8 = Post.of(user3, category, "llo world hello", "content");
+        Post post9 = Post.of(user3, category, "hhhhh", "content");
+        Post post10 = Post.of(user3, category, "test", "content");
          */
         return Stream.of(
-                arguments(null, null, List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_6, TITLE_7, TITLE_8, TITLE_9, TITLE_10)),
-                arguments("writer", null, List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_6, TITLE_7, TITLE_8, TITLE_9, TITLE_10)),
-                arguments("WRITER", null, List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_6, TITLE_7, TITLE_8, TITLE_9, TITLE_10)),
-                arguments("writer1", null, List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_6)),
-                arguments("writer2", null, List.of(TITLE_7, TITLE_8, TITLE_9, TITLE_10)),
-                arguments(null, "Hello World", List.of(TITLE_1, TITLE_3)),
-                arguments(null, "hello", List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_8)),
-                arguments(null, "world", List.of(TITLE_1, TITLE_3, TITLE_6, TITLE_8)),
-                arguments(null, "llo world", List.of(TITLE_1, TITLE_3, TITLE_8)),
-                arguments(null, "test", List.of(TITLE_10)),
-                arguments(null, "hhh", List.of(TITLE_9)),
-                arguments("writer1", "test", List.of()),
-                arguments("writer1", "hello", List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5)),
-                arguments("writer2", "test", List.of(TITLE_10)),
-                arguments("writer2", "worl", List.of(TITLE_7, TITLE_8)),
-                arguments(null, "something", List.of())
+                arguments(null, List.of()),
+                arguments("", List.of()),
+                arguments("writer", List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_6, TITLE_7)),
+                arguments("WRITER", List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_6, TITLE_7)),
+                arguments("writer1", List.of(TITLE_1, TITLE_2, TITLE_3)),
+                arguments("writer2", List.of(TITLE_4, TITLE_5, TITLE_6, TITLE_7)),
+                arguments("user", List.of(TITLE_8, TITLE_9, TITLE_10)),
+                arguments("user3", List.of(TITLE_8, TITLE_9, TITLE_10))
+        );
+    }
+
+    static Stream<Arguments> findPostPageByTitle() {
+        /*
+        Post post1 = Post.of(user1, category, "Hello World", "content");
+        Post post2 = Post.of(user1, category, "hello w", "content");
+        Post post3 = Post.of(user1, category, "Hello world?", "content");
+        Post post4 = Post.of(user2, category, "hello wor", "content");
+        Post post5 = Post.of(user2, category, "Hello worl", "content");
+        Post post6 = Post.of(user2, category, "WORLD", "content");
+        Post post7 = Post.of(user2, category, "worl", "content");
+        Post post8 = Post.of(user3, category, "llo world hello", "content");
+        Post post9 = Post.of(user3, category, "hhhhh", "content");
+        Post post10 = Post.of(user3, category, "test", "content");
+         */
+        return Stream.of(
+                arguments(null, List.of()),
+                arguments("", List.of()),
+                arguments("Hello World", List.of(TITLE_1, TITLE_3)),
+                arguments("hello", List.of(TITLE_1, TITLE_2, TITLE_3, TITLE_4, TITLE_5, TITLE_8)),
+                arguments("world", List.of(TITLE_1, TITLE_3, TITLE_6, TITLE_8)),
+                arguments("llo world", List.of(TITLE_1, TITLE_3, TITLE_8)),
+                arguments("test", List.of(TITLE_10)),
+                arguments("hhh", List.of(TITLE_9)),
+                arguments("worl", List.of(TITLE_1, TITLE_3, TITLE_5, TITLE_6, TITLE_7, TITLE_8)),
+                arguments("something", List.of())
         );
     }
 

--- a/src/test/java/com/been/foodieserver/service/PostSearchServiceTest.java
+++ b/src/test/java/com/been/foodieserver/service/PostSearchServiceTest.java
@@ -2,6 +2,7 @@ package com.been.foodieserver.service;
 
 import com.been.foodieserver.domain.Post;
 import com.been.foodieserver.dto.PostSearchDto;
+import com.been.foodieserver.dto.PostSearchType;
 import com.been.foodieserver.dto.response.PostResponse;
 import com.been.foodieserver.fixture.PostFixture;
 import com.been.foodieserver.repository.PostQueryRepository;
@@ -36,10 +37,9 @@ class PostSearchServiceTest {
     void searchPost_IfRequestIsValid() {
         //Given
         String searchTitle = "searchTitle";
-        String searchLoginId = "writer";
 
-        Post post1 = PostFixture.get("title1", searchLoginId, "자유 게시판");
-        Post post2 = PostFixture.get("title2", searchLoginId, "자유 게시판");
+        Post post1 = PostFixture.get("title1", "writer", "자유 게시판");
+        Post post2 = PostFixture.get("title2", "writer", "자유 게시판");
 
         int pageNum = 1;
         int pageSize = 10;
@@ -49,13 +49,13 @@ class PostSearchServiceTest {
         Page<Post> postPage = new PageImpl<>(content, pageable, content.size());
 
         PostSearchDto dto = PostSearchDto.builder()
-                .writerLoginId(searchLoginId)
-                .title(searchTitle)
+                .searchType(PostSearchType.TITLE)
+                .keyword(searchTitle)
                 .pageNum(pageNum)
                 .pageSize(pageSize)
                 .build();
 
-        given(postQueryRepository.findAllByUserLoginIdContainsIgnoreCaseAndTitleContainsIgnoreCase(dto)).willReturn(postPage);
+        given(postQueryRepository.findAllByTitleContainsIgnoreCase(dto)).willReturn(postPage);
 
         //When
         Page<PostResponse> result = postSearchService.search(dto);
@@ -67,6 +67,6 @@ class PostSearchServiceTest {
         assertThat(result.getSize()).isEqualTo(pageSize);
         assertThat(result.getContent().get(0).getTitle()).isEqualTo(post2.getTitle());
 
-        then(postQueryRepository).should().findAllByUserLoginIdContainsIgnoreCaseAndTitleContainsIgnoreCase(dto);
+        then(postQueryRepository).should().findAllByTitleContainsIgnoreCase(dto);
     }
 }


### PR DESCRIPTION
검색 시 작성자 아이디가 아닌 닉네임으로 검색하게 수정한다.

원래는 검색 시 작성자 닉네임, 게시글 제목 둘을 동시에 조건을 두고 검색할 수 있었다.
그런데 검색은 조건이 한 가지만 적용되면 될 것 같아서 한 조건씩만 적용되게 수정한다.
이에 따라 검색 조건을 담을 `PostSearchType` enum을 생성한다.